### PR TITLE
better integration tests

### DIFF
--- a/action_subscriber.gemspec
+++ b/action_subscriber.gemspec
@@ -34,5 +34,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry-nav"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "simplecov"
 end

--- a/lib/action_subscriber/rabbit_connection.rb
+++ b/lib/action_subscriber/rabbit_connection.rb
@@ -36,5 +36,15 @@ module ActionSubscriber
         :recover_from_connection_close => true,
       }
     end
+
+    def self.disconnect!
+      CONNECTION_MUTEX.synchronize do
+        if @connection && @connection.connected?
+          @connection.close
+        end
+
+        @connection = nil
+      end
+    end
   end
 end

--- a/spec/integration/basic_subscriber_spec.rb
+++ b/spec/integration/basic_subscriber_spec.rb
@@ -1,42 +1,50 @@
 require 'spec_helper'
 
 class BasicPushSubscriber < ActionSubscriber::Base
-  BOOKED_MESSAGES = []
-  CANCELLED_MESSAGES = []
-
   publisher :greg
 
   # queue => alice.greg.basic_push.booked
   # routing_key => greg.basic_push.booked
   def booked
-    BOOKED_MESSAGES << payload
+    $messages << payload
   end
 
   queue_for :cancelled, "basic.cancelled"
   routing_key_for :cancelled, "basic.cancelled"
 
   def cancelled
-    CANCELLED_MESSAGES << payload
+    $messages << payload
   end
 end
 
-describe "A Basic Subscriber using Push API", :integration => true do
+describe "A Basic Subscriber", :integration => true do
   let(:connection) { subscriber.connection }
   let(:subscriber) { BasicPushSubscriber }
 
-  it "messages are routed to the right place" do
-    ::ActionSubscriber.start_queues
+  context "ActionSubscriber.auto_pop!" do
+    it "routes messages to the right place" do
+      channel = connection.create_channel
+      exchange = channel.topic("events")
+      exchange.publish("Ohai Booked", :routing_key => "greg.basic_push.booked")
+      exchange.publish("Ohai Cancelled", :routing_key => "basic.cancelled")
 
-    channel = connection.create_channel
-    exchange = channel.topic("events")
-    exchange.publish("Ohai Booked", :routing_key => "greg.basic_push.booked")
-    exchange.publish("Ohai Cancelled", :routing_key => "basic.cancelled")
+      ::ActionSubscriber.auto_pop!
 
-    ::ActionSubscriber.auto_pop!
+      expect($messages).to eq(Set.new(["Ohai Booked", "Ohai Cancelled"]))
+    end
+  end
 
-    expect(subscriber::BOOKED_MESSAGES).to eq(["Ohai Booked"])
-    expect(subscriber::CANCELLED_MESSAGES).to eq(["Ohai Cancelled"])
+  context "ActionSubscriber.auto_subscribe!" do
+    it "routes messages to the right place" do
+      channel = connection.create_channel
+      exchange = channel.topic("events")
+      exchange.publish("Ohai Booked", :routing_key => "greg.basic_push.booked")
+      exchange.publish("Ohai Cancelled", :routing_key => "basic.cancelled")
 
-    connection.close
+      ::ActionSubscriber.auto_subscribe!
+      sleep 0.1
+
+      expect($messages).to eq(Set.new(["Ohai Booked", "Ohai Cancelled"]))
+    end
   end
 end


### PR DESCRIPTION
I want to support having multiple integration tests so that I can get good coverage of all our major features like supporting custom content types, at_least_once!, at_most_once! etc.
Here I have attempted to simplify the process of how an integration test works by keeping the details in spec/spec_helper.rb
Currently the process for cleaning up at the end of a test run is pretty gross, but I just wanted a proof of concept with two integration tests before I add the rest of the test coverage.
I also removed simplecov since I never use it

/cc @quixoten @brianstien @abrandoned @liveh2o 