### PR TITLE
Decoder coverage

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --colour
 --order rand
+--require spec_helper

--- a/spec/integration/at_least_once_spec.rb
+++ b/spec/integration/at_least_once_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 class GorbyPuffSubscriber < ActionSubscriber::Base
   at_least_once!
 

--- a/spec/integration/at_most_once_spec.rb
+++ b/spec/integration/at_most_once_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 class PokemonSubscriber < ActionSubscriber::Base
   at_most_once!
 

--- a/spec/integration/basic_subscriber_spec.rb
+++ b/spec/integration/basic_subscriber_spec.rb
@@ -27,6 +27,7 @@ describe "A Basic Subscriber", :integration => true do
       exchange = channel.topic("events")
       exchange.publish("Ohai Booked", :routing_key => "greg.basic_push.booked")
       exchange.publish("Ohai Cancelled", :routing_key => "basic.cancelled")
+      sleep 0.1
 
       ::ActionSubscriber.auto_pop!
 

--- a/spec/integration/basic_subscriber_spec.rb
+++ b/spec/integration/basic_subscriber_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 class BasicPushSubscriber < ActionSubscriber::Base
   publisher :greg
 

--- a/spec/integration/decoding_payloads_spec.rb
+++ b/spec/integration/decoding_payloads_spec.rb
@@ -1,0 +1,48 @@
+class TwitterSubscriber < ActionSubscriber::Base
+  def tweet
+    $messages << {
+      :decoded => payload,
+      :raw => raw_payload,
+    }
+  end
+end
+
+
+describe "Payload Decoding", :integration => true do
+  let(:connection) { subscriber.connection }
+  let(:subscriber) { TwitterSubscriber }
+  let(:json_string) { '{"foo": "bar"}' }
+
+  it "decodes json by default" do
+    ::ActionSubscriber.auto_subscribe!
+    channel = connection.create_channel
+    exchange = channel.topic("events")
+    exchange.publish(json_string, :routing_key => "twitter.tweet", :content_type => "application/json")
+    sleep 0.1
+
+    expect($messages).to eq Set.new([{
+      :decoded => JSON.parse(json_string),
+      :raw => json_string,
+    }])
+  end
+
+  context "Custom Decoder" do
+    let(:content_type) { "foo/type" }
+
+    before { ::ActionSubscriber.config.add_decoder(content_type => lambda{ |payload| :foo }) }
+    after { ::ActionSubscriber.config.decoder.delete(content_type) }
+
+    it "it decodes the payload using the custom decoder" do
+      ::ActionSubscriber.auto_subscribe!
+      channel = connection.create_channel
+      exchange = channel.topic("events")
+      exchange.publish(json_string, :routing_key => "twitter.tweet", :content_type => content_type)
+      sleep 0.1
+
+      expect($messages).to eq Set.new([{
+        :decoded => :foo,
+        :raw => json_string,
+      }])
+    end
+  end
+end

--- a/spec/integration/manual_acknowledgement_spec.rb
+++ b/spec/integration/manual_acknowledgement_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 class BaconSubscriber < ActionSubscriber::Base
   manual_acknowledgement!
 

--- a/spec/lib/action_subscriber/base_spec.rb
+++ b/spec/lib/action_subscriber/base_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 class TestObject < ActionSubscriber::Base
   exchange :events
 

--- a/spec/lib/action_subscriber/configuration_spec.rb
+++ b/spec/lib/action_subscriber/configuration_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe ::ActionSubscriber::Configuration do
   describe "default values" do
     specify { expect(subject.allow_low_priority_methods).to eq(false) }

--- a/spec/lib/action_subscriber/dsl_spec.rb
+++ b/spec/lib/action_subscriber/dsl_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe ::ActionSubscriber::DSL do
   let(:subscriber) { Object.new }
   before { subscriber.extend(::ActionSubscriber::DSL) }

--- a/spec/lib/action_subscriber/middleware/active_record/connection_management_spec.rb
+++ b/spec/lib/action_subscriber/middleware/active_record/connection_management_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'action_subscriber/middleware/active_record/connection_management'
 
 describe ActionSubscriber::Middleware::ActiveRecord::ConnectionManagement do

--- a/spec/lib/action_subscriber/middleware/active_record/query_cache_spec.rb
+++ b/spec/lib/action_subscriber/middleware/active_record/query_cache_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'action_subscriber/middleware/active_record/query_cache'
 
 describe ActionSubscriber::Middleware::ActiveRecord::QueryCache do

--- a/spec/lib/action_subscriber/middleware/decoder_spec.rb
+++ b/spec/lib/action_subscriber/middleware/decoder_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe ActionSubscriber::Middleware::Decoder do
   include_context 'action subscriber middleware env'
 

--- a/spec/lib/action_subscriber/middleware/env_spec.rb
+++ b/spec/lib/action_subscriber/middleware/env_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe ActionSubscriber::Middleware::Env do
   let(:channel) { double("channel") }
   let(:encoded_payload) { 'encoded_payload' }

--- a/spec/lib/action_subscriber/middleware/error_handler_spec.rb
+++ b/spec/lib/action_subscriber/middleware/error_handler_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'action_subscriber/middleware/error_handler'
 
 describe ActionSubscriber::Middleware::ErrorHandler do

--- a/spec/lib/action_subscriber/middleware/router_spec.rb
+++ b/spec/lib/action_subscriber/middleware/router_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe ActionSubscriber::Middleware::Router do
   include_context 'action subscriber middleware env'
 

--- a/spec/lib/action_subscriber/middleware/runner_spec.rb
+++ b/spec/lib/action_subscriber/middleware/runner_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe ActionSubscriber::Middleware::Runner do
   # TODO: Figure out at way to test this...
   it "adds the router to the top of the stack"

--- a/spec/lib/action_subscriber/subscribable_spec.rb
+++ b/spec/lib/action_subscriber/subscribable_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 TestSubscriber = Class.new(ActionSubscriber::Base) do
   def updated
   end

--- a/spec/lib/action_subscriber/threadpool_spec.rb
+++ b/spec/lib/action_subscriber/threadpool_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe ::ActionSubscriber::Threadpool do
   describe "busy?" do
     context "when the workers are busy" do


### PR DESCRIPTION
Adds an integration test for the default JSON decoder as well as adding a custom decoder.

I also moved the `require "spec_helper"` call to .rspec which is the standard thing rspec does today if you run `rspec --init`