### PR TITLE
Connection recovery test

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,19 +70,21 @@ ActionSubscriber needs to know how to connect to your rabbit server to start get
 In an initializer, you can set the host and the port like this :
 
     ActionSubscriber::Configuration.configure do |config|
-      config.host = "my rabbit host"
+      config.hosts = ["rabbit1", "rabbit2", "rabbit3"]
       config.port = 5672
     end
 
 Other configuration options include :
 
+* config.add_decoder - add a custom decoder for a custom content type
 * config.allow_low_priority_methods - subscribe to queues for methods suffixed with "_low"
 * config.default_exchange - set the default exchange that your queues will use, using the default RabbitMQ exchange is not recommended
-* config.hosts - an array of hostnames in your cluster
-* config.times_to_pop - when using RabbitMQ's pull API, the number of messages we will grab each time we pool the broker
-* config.threadpool_size - set the number of threads availiable to action_subscriber
 * config.error_handler - handle error like you want to handle them!
-* config.add_decoder - add a custom decoder for a custom content type
+* config.heartbeat - number of seconds between hearbeats (default 5) [see bunny documentation for more details](http://rubybunny.info/articles/connecting.html)
+* config.hosts - an array of hostnames in your cluster
+* config.threadpool_size - set the number of threads availiable to action_subscriber
+* config.timeout - how many seconds to allow rabbit to respond before timing out
+* config.times_to_pop - when using RabbitMQ's pull API, the number of messages we will grab each time we pool the broker
 
 Message Acknowledgment
 ----------------------

--- a/action_subscriber.gemspec
+++ b/action_subscriber.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "activerecord", ">= 3.2"
   spec.add_development_dependency "bundler", ">= 1.6"
   spec.add_development_dependency "pry-nav"
+  spec.add_development_dependency "rabbitmq_http_api_client", "~> 1.2.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rake"
 end

--- a/spec/integration/automatic_reconnect_spec.rb
+++ b/spec/integration/automatic_reconnect_spec.rb
@@ -1,0 +1,34 @@
+require "rabbitmq/http/client"
+
+class GusSubscriber < ActionSubscriber::Base
+  def spoke
+    $messages << payload
+  end
+end
+
+describe "Automatically reconnect on connection failure", :integration => true, :slow => true do
+  let(:connection) { subscriber.connection }
+  let(:http_client) { RabbitMQ::HTTP::Client.new("http://127.0.0.1:15672") }
+  let(:subscriber) { GusSubscriber }
+
+  it "reconnects when a connection drops" do
+    ::ActionSubscriber::auto_subscribe!
+    channel = connection.create_channel
+    exchange = channel.topic("events")
+    exchange.publish("First", :routing_key => "gus.spoke")
+    sleep 0.1
+
+    close_all_connections!
+    sleep 5.0
+    exchange.publish("Second", :routing_key => "gus.spoke")
+    sleep 0.1
+
+    expect($messages).to eq(Set.new(["First", "Second"]))
+  end
+
+  def close_all_connections!
+    http_client.list_connections.each do |conn_info|
+      http_client.close_connection(conn_info.name)
+    end
+  end
+end

--- a/spec/integration/automatic_reconnect_spec.rb
+++ b/spec/integration/automatic_reconnect_spec.rb
@@ -38,5 +38,6 @@ describe "Automatically reconnect on connection failure", :integration => true, 
       sleep 0.1
       break if connection.open?
     end
+    sleep 0.2
   end
 end

--- a/spec/integration/automatic_reconnect_spec.rb
+++ b/spec/integration/automatic_reconnect_spec.rb
@@ -19,7 +19,8 @@ describe "Automatically reconnect on connection failure", :integration => true, 
     sleep 0.1
 
     close_all_connections!
-    sleep 5.0
+    sleep_until_reconnected
+
     exchange.publish("Second", :routing_key => "gus.spoke")
     sleep 0.1
 
@@ -29,6 +30,13 @@ describe "Automatically reconnect on connection failure", :integration => true, 
   def close_all_connections!
     http_client.list_connections.each do |conn_info|
       http_client.close_connection(conn_info.name)
+    end
+  end
+
+  def sleep_until_reconnected
+    100.times do
+      sleep 0.1
+      break if connection.open?
     end
   end
 end


### PR DESCRIPTION
Adds an integration test for automatically recovering from dropped connections.

Note: this test is significantly slower than the others so I tagged it with `:integration => true, :slow => true`. The test will still be executed on the CI server but you can skip it during normal development by running `rspec --tag ~slow` or just run the unit tests with `rspec spec/lib`

I also updated the README to reflect some of the recent changes about how to configure ActionSubscriber