### PR TITLE
support nested around filters

### DIFF
--- a/lib/action_subscriber/base.rb
+++ b/lib/action_subscriber/base.rb
@@ -76,6 +76,19 @@ module ActionSubscriber
       env.acknowledge
     end
 
+    def _at_least_once_filter
+      yield
+      acknowledge
+    rescue => error
+      reject
+      raise error
+    end
+
+    def _at_most_once_filter
+      acknowledge
+      yield
+    end
+
     def reject
       env.reject
     end

--- a/lib/action_subscriber/dsl.rb
+++ b/lib/action_subscriber/dsl.rb
@@ -90,10 +90,10 @@ module ActionSubscriber
 
     def run_action_with_filters(env, action)
       subscriber_instance = self.new(env)
-      final_block = ->{ subscriber_instance.public_send(action) }
+      final_block = Proc.new { subscriber_instance.public_send(action) }
 
       first_proc = around_filters.reverse.reduce(final_block) do |block, filter|
-        ->{ subscriber_instance.send(filter, &block) }
+        Proc.new { subscriber_instance.send(filter, &block) }
       end
       first_proc.call
     end

--- a/lib/action_subscriber/dsl.rb
+++ b/lib/action_subscriber/dsl.rb
@@ -2,24 +2,16 @@ module ActionSubscriber
   module DSL
     def at_least_once!
       @_acknowledge_messages = true
-      @_acknowledge_messages_after_processing = true
+      around_filter :_at_least_once_filter
     end
 
     def at_most_once!
       @_acknowledge_messages = true
-      @_acknowledge_messages_before_processing = true
+      around_filter :_at_most_once_filter
     end
 
     def acknowledge_messages?
       !!@_acknowledge_messages
-    end
-
-    def acknowledge_messages_after_processing?
-      !!@_acknowledge_messages_after_processing
-    end
-
-    def acknowledge_messages_before_processing?
-      !!@_acknowledge_messages_before_processing
     end
 
     def around_filter(filter_method)

--- a/lib/action_subscriber/middleware/error_handler.rb
+++ b/lib/action_subscriber/middleware/error_handler.rb
@@ -8,7 +8,6 @@ module ActionSubscriber
       def call(env)
         @app.call(env)
       rescue => error
-        env.reject if env.subscriber.acknowledge_messages_after_processing?
         ::ActionSubscriber.configuration.error_handler.call(error, env.to_h)
       end
     end

--- a/lib/action_subscriber/middleware/router.rb
+++ b/lib/action_subscriber/middleware/router.rb
@@ -6,10 +6,8 @@ module ActionSubscriber
       end
 
       def call(env)
-        subscriber = env.subscriber.new(env)
-
         env.acknowledge if env.subscriber.acknowledge_messages_before_processing?
-        subscriber.public_send(env.action)
+        env.subscriber.run_action_with_filters(env, env.action)
         env.acknowledge if env.subscriber.acknowledge_messages_after_processing?
       end
     end

--- a/lib/action_subscriber/middleware/router.rb
+++ b/lib/action_subscriber/middleware/router.rb
@@ -6,9 +6,7 @@ module ActionSubscriber
       end
 
       def call(env)
-        env.acknowledge if env.subscriber.acknowledge_messages_before_processing?
         env.subscriber.run_action_with_filters(env, env.action)
-        env.acknowledge if env.subscriber.acknowledge_messages_after_processing?
       end
     end
   end

--- a/spec/integration/around_filters_spec.rb
+++ b/spec/integration/around_filters_spec.rb
@@ -1,0 +1,38 @@
+class InstaSubscriber < ActionSubscriber::Base
+  around_filter :whisper
+  around_filter :yell
+
+  def first
+    $messages << payload
+  end
+
+  private
+
+  def whisper
+    $messages << :whisper_before
+    yield
+    $messages << :whisper_after
+  end
+
+  def yell
+    $messages << :yell_before
+    yield
+    $messages << :yell_after
+  end
+end
+
+describe "subscriber filters", :integration => true do
+  let(:connection) { subscriber.connection }
+  let(:subscriber) { InstaSubscriber }
+
+  it "runs multiple around filters" do
+    $messages = []  #testing the order of things
+    ::ActionSubscriber.auto_subscribe!
+    channel = connection.create_channel
+    exchange = channel.topic("events")
+    exchange.publish("hEY Guyz!", :routing_key => "insta.first")
+    sleep 0.1
+
+    expect($messages).to eq [:whisper_before, :yell_before, "hEY Guyz!", :yell_after, :whisper_after]
+  end
+end

--- a/spec/lib/action_subscriber/dsl_spec.rb
+++ b/spec/lib/action_subscriber/dsl_spec.rb
@@ -13,14 +13,6 @@ describe ::ActionSubscriber::DSL do
       it "returns expected queue subscription options" do
         expect(subscriber.queue_subscription_options).to eq( :manual_ack => true )
       end
-
-      it "does not acknowledge messages after processing them" do
-        expect(subscriber.acknowledge_messages_after_processing?).to eq(false)
-      end
-
-      it "does not acknowledge messages before processing them" do
-        expect(subscriber.acknowledge_messages_before_processing?).to eq(false)
-      end
     end
 
     context "when at_most_once! is set" do
@@ -28,14 +20,6 @@ describe ::ActionSubscriber::DSL do
 
       it "acknowledges messages" do
         expect(subscriber.acknowledge_messages?).to eq(true)
-      end
-
-      it "acknowledges messages before processing them" do
-        expect(subscriber.acknowledge_messages_before_processing?).to eq(true)
-      end
-
-      it "does not acknowledge messages after processing them" do
-        expect(subscriber.acknowledge_messages_after_processing?).to eq(false)
       end
     end
 
@@ -45,14 +29,6 @@ describe ::ActionSubscriber::DSL do
       it "acknowledges messages" do
         expect(subscriber.acknowledge_messages?).to eq(true)
       end
-
-      it "does not acknowledge messages before processing them" do
-        expect(subscriber.acknowledge_messages_before_processing?).to eq(false)
-      end
-
-      it "acknowledges messages after processing them" do
-        expect(subscriber.acknowledge_messages_after_processing?).to eq(true)
-      end
     end
 
     context "when no_acknowledgement! is set" do
@@ -61,27 +37,11 @@ describe ::ActionSubscriber::DSL do
       it "does not acknowledge messages" do
         expect(subscriber.acknowledge_messages?).to eq(false)
       end
-
-      it "does not acknowledge messages after processing them" do
-        expect(subscriber.acknowledge_messages_after_processing?).to eq(false)
-      end
-
-      it "does not acknowledge messages before processing them" do
-        expect(subscriber.acknowledge_messages_before_processing?).to eq(false)
-      end
     end
 
     context "default" do
       it "does not acknowledge messages" do
         expect(subscriber.acknowledge_messages?).to eq(false)
-      end
-
-      it "does not acknowledge messages after processing them" do
-        expect(subscriber.acknowledge_messages_after_processing?).to eq(false)
-      end
-
-      it "does not acknowledge messages before processing them" do
-        expect(subscriber.acknowledge_messages_before_processing?).to eq(false)
       end
     end
   end

--- a/spec/lib/action_subscriber/middleware/error_handler_spec.rb
+++ b/spec/lib/action_subscriber/middleware/error_handler_spec.rb
@@ -18,17 +18,5 @@ describe ActionSubscriber::Middleware::ErrorHandler do
 
       subject.call(env)
     end
-
-    context "when the subscriber was expecting to acknowledge the message" do
-      before { allow(env.subscriber).to receive(:acknowledge_messages_after_processing?).and_return(true) }
-
-      it "calls the exception handler and rejects the message" do
-        handler = ::ActionSubscriber.configuration.error_handler
-        expect(handler).to receive(:call).with(error, env.to_h)
-        expect(env).to receive(:reject).with(no_args)
-
-        subject.call(env)
-      end
-    end
   end
 end

--- a/spec/lib/action_subscriber/middleware/router_spec.rb
+++ b/spec/lib/action_subscriber/middleware/router_spec.rb
@@ -7,16 +7,4 @@ describe ActionSubscriber::Middleware::Router do
     allow_any_instance_of(env.subscriber).to receive(env.action)
     subject.call(env)
   end
-
-  it "acknowledges messages after processing if the subscriber flag is set" do
-    allow(env.subscriber).to receive(:acknowledge_messages_after_processing?).and_return(true)
-    expect(env).to receive(:acknowledge)
-    subject.call(env)
-  end
-
-  it "acknowledges messages before processing if the subscriber flag is set" do
-    allow(env.subscriber).to receive(:acknowledge_messages_before_processing?).and_return(true)
-    expect(env).to receive(:acknowledge)
-    subject.call(env)
-  end
 end


### PR DESCRIPTION
I'm adding the idea of `around_filters` for a subscriber. This is a stepping stone for me to move the implementation of `at_least_once!` and `at_most_once!` modes into filters rather than having the implementation being spread throughout the codebase.

For now I'm not adding any other options to these filters (ie. `:only => [:this_action]` or `:except => [:that_action]`), because I don't need those features so I just made it as simple as I could.