### PR TITLE
Separate connections

### DIFF
--- a/lib/action_subscriber/base.rb
+++ b/lib/action_subscriber/base.rb
@@ -32,7 +32,7 @@ module ActionSubscriber
     #
 
     def self.connection
-      ::ActionSubscriber::RabbitConnection.connection
+      ::ActionSubscriber::RabbitConnection.subscriber_connection
     end
 
     # Inherited callback, save a reference to our descendents

--- a/lib/action_subscriber/default_routing.rb
+++ b/lib/action_subscriber/default_routing.rb
@@ -8,7 +8,7 @@ module ActionSubscriber
       queue_name = queue_name_for_method(method_name)
       routing_key_name = routing_key_name_for_method(method_name)
 
-      channel = ::ActionSubscriber::RabbitConnection.connection.create_channel
+      channel = connection.create_channel
       exchange = channel.topic(exchange_name)
       queue = channel.queue(queue_name)
       queue.bind(exchange, :routing_key => routing_key_name)

--- a/lib/action_subscriber/rabbit_connection.rb
+++ b/lib/action_subscriber/rabbit_connection.rb
@@ -3,6 +3,28 @@ require 'thread'
 module ActionSubscriber
   module RabbitConnection
     SUBSCRIBER_CONNECTION_MUTEX = ::Mutex.new
+    PUBLISHER_CONNECTION_MUTEX = ::Mutex.new
+
+    def self.publisher_connected?
+      publisher_connection.try(:connected?)
+    end
+
+    def self.publisher_connection
+      SUBSCRIBER_CONNECTION_MUTEX.synchronize do
+        return @publisher_connection if @publisher_connection
+        @publisher_connection = create_connection
+      end
+    end
+
+    def self.publisher_disconnect!
+      SUBSCRIBER_CONNECTION_MUTEX.synchronize do
+        if @publisher_connection && @publisher_connection.connected?
+          @publisher_connection.close
+        end
+
+        @publisher_connection = nil
+      end
+    end
 
     def self.subscriber_connected?
       subscriber_connection.try(:connected?)

--- a/lib/action_subscriber/rabbit_connection.rb
+++ b/lib/action_subscriber/rabbit_connection.rb
@@ -2,26 +2,26 @@ require 'thread'
 
 module ActionSubscriber
   module RabbitConnection
-    CONNECTION_MUTEX = ::Mutex.new
+    SUBSCRIBER_CONNECTION_MUTEX = ::Mutex.new
 
-    def self.connected?
-      connection.try(:connected?)
+    def self.subscriber_connected?
+      subscriber_connection.try(:connected?)
     end
 
-    def self.connection
-      CONNECTION_MUTEX.synchronize do
-        return @connection if @connection
-        @connection = create_connection
+    def self.subscriber_connection
+      SUBSCRIBER_CONNECTION_MUTEX.synchronize do
+        return @subscriber_connection if @subscriber_connection
+        @subscriber_connection = create_connection
       end
     end
 
-    def self.disconnect!
-      CONNECTION_MUTEX.synchronize do
-        if @connection && @connection.connected?
-          @connection.close
+    def self.subscriber_disconnect!
+      SUBSCRIBER_CONNECTION_MUTEX.synchronize do
+        if @subscriber_connection && @subscriber_connection.connected?
+          @subscriber_connection.close
         end
 
-        @connection = nil
+        @subscriber_connection = nil
       end
     end
 

--- a/lib/action_subscriber/rabbit_connection.rb
+++ b/lib/action_subscriber/rabbit_connection.rb
@@ -4,26 +4,38 @@ module ActionSubscriber
   module RabbitConnection
     CONNECTION_MUTEX = ::Mutex.new
 
-    def self.connect!
-      CONNECTION_MUTEX.synchronize do
-        return @connection if @connection
-        if ::RUBY_PLATFORM == "java"
-          @connection = ::MarchHare.connect(connection_options)
-        else
-          @connection = ::Bunny.new(connection_options)
-          @connection.start
-        end
-        @connection
-      end
-    end
-
     def self.connected?
-      connection && connection.connected?
+      connection.try(:connected?)
     end
 
     def self.connection
-      connect!
+      CONNECTION_MUTEX.synchronize do
+        return @connection if @connection
+        @connection = create_connection
+      end
     end
+
+    def self.disconnect!
+      CONNECTION_MUTEX.synchronize do
+        if @connection && @connection.connected?
+          @connection.close
+        end
+
+        @connection = nil
+      end
+    end
+
+    # Private API
+    def self.create_connection
+      if ::RUBY_PLATFORM == "java"
+        connection = ::MarchHare.connect(connection_options)
+      else
+        connection = ::Bunny.new(connection_options)
+        connection.start
+        connection
+      end
+    end
+    private_class_method :create_connection
 
     def self.connection_options
       {
@@ -36,15 +48,6 @@ module ActionSubscriber
         :recover_from_connection_close => true,
       }
     end
-
-    def self.disconnect!
-      CONNECTION_MUTEX.synchronize do
-        if @connection && @connection.connected?
-          @connection.close
-        end
-
-        @connection = nil
-      end
-    end
+    private_class_method :connection_options
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,11 +20,11 @@ RSpec.configure do |config|
 
   config.before(:each, :integration => true) do
     $messages = Set.new
-    ::ActionSubscriber::RabbitConnection.connection
+    ::ActionSubscriber::RabbitConnection.subscriber_connection
     ::ActionSubscriber.setup_queues!
   end
   config.after(:each, :integration => true) do
-    ::ActionSubscriber::RabbitConnection.disconnect!
+    ::ActionSubscriber::RabbitConnection.subscriber_disconnect!
     ::ActionSubscriber::Base.inherited_classes.each do |klass|
       klass.instance_variable_set("@_queues", nil)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ RSpec.configure do |config|
 
   config.before(:each, :integration => true) do
     $messages = Set.new
-    ::ActionSubscriber::RabbitConnection.connect!
+    ::ActionSubscriber::RabbitConnection.connection
     ::ActionSubscriber.setup_queues!
   end
   config.after(:each, :integration => true) do


### PR DESCRIPTION
Part of #14

Create a separate interface for handling a publishing connection from the subscriber connection. I still need to add the actual publishing code and an ActiveRecord mixin, but this starts us down the path towards having a separate connection for publishing and subscribing.

/cc @brettallred @localshred @liveh2o @abrandoned 