### PR TITLE
Less flakey tests

### DIFF
--- a/spec/integration/around_filters_spec.rb
+++ b/spec/integration/around_filters_spec.rb
@@ -31,8 +31,9 @@ describe "subscriber filters", :integration => true do
     channel = connection.create_channel
     exchange = channel.topic("events")
     exchange.publish("hEY Guyz!", :routing_key => "insta.first")
-    sleep 0.1
 
-    expect($messages).to eq [:whisper_before, :yell_before, "hEY Guyz!", :yell_after, :whisper_after]
+    verify_expectation_within(1.0) do
+      expect($messages).to eq [:whisper_before, :yell_before, "hEY Guyz!", :yell_after, :whisper_after]
+    end
   end
 end

--- a/spec/integration/at_least_once_spec.rb
+++ b/spec/integration/at_least_once_spec.rb
@@ -16,8 +16,9 @@ describe "at_least_once! mode", :integration => true do
     channel = connection.create_channel
     exchange = channel.topic("events")
     exchange.publish("GrumpFace", :routing_key => "gorby_puff.grumpy")
-    sleep 0.1
 
-    expect($messages).to eq Set.new(["GrumpFace::0","GrumpFace::1","GrumpFace::2"])
+    verify_expectation_within(1.0) do
+      expect($messages).to eq Set.new(["GrumpFace::0","GrumpFace::1","GrumpFace::2"])
+    end
   end
 end

--- a/spec/integration/at_most_once_spec.rb
+++ b/spec/integration/at_most_once_spec.rb
@@ -16,8 +16,9 @@ describe "at_most_once! mode", :integration => true do
     channel = connection.create_channel
     exchange = channel.topic("events")
     exchange.publish("All Pokemon have been caught", :routing_key => "pokemon.caught_em_all")
-    sleep 0.1
 
-    expect($messages.size).to eq 1
+    verify_expectation_within(1.0) do
+      expect($messages.size).to eq 1
+    end
   end
 end

--- a/spec/integration/automatic_reconnect_spec.rb
+++ b/spec/integration/automatic_reconnect_spec.rb
@@ -16,28 +16,24 @@ describe "Automatically reconnect on connection failure", :integration => true, 
     channel = connection.create_channel
     exchange = channel.topic("events")
     exchange.publish("First", :routing_key => "gus.spoke")
-    sleep 0.1
+    verify_expectation_within(5.0) do
+      expect($messages).to eq(Set.new(["First"]))
+    end
 
     close_all_connections!
-    sleep_until_reconnected
+    verify_expectation_within(10.0) do
+      expect(connection).to be_open
+    end
 
     exchange.publish("Second", :routing_key => "gus.spoke")
-    sleep 0.1
-
-    expect($messages).to eq(Set.new(["First", "Second"]))
+    verify_expectation_within(5.0) do
+      expect($messages).to eq(Set.new(["First", "Second"]))
+    end
   end
 
   def close_all_connections!
     http_client.list_connections.each do |conn_info|
       http_client.close_connection(conn_info.name)
     end
-  end
-
-  def sleep_until_reconnected
-    100.times do
-      sleep 0.1
-      break if connection.open?
-    end
-    sleep 0.2
   end
 end

--- a/spec/integration/automatic_reconnect_spec.rb
+++ b/spec/integration/automatic_reconnect_spec.rb
@@ -21,10 +21,13 @@ describe "Automatically reconnect on connection failure", :integration => true, 
     end
 
     close_all_connections!
-    verify_expectation_within(10.0) do
+    sleep 5.0
+    verify_expectation_within(5.0) do
       expect(connection).to be_open
     end
 
+    channel = connection.create_channel
+    exchange = channel.topic("events")
     exchange.publish("Second", :routing_key => "gus.spoke")
     verify_expectation_within(5.0) do
       expect($messages).to eq(Set.new(["First", "Second"]))

--- a/spec/integration/basic_subscriber_spec.rb
+++ b/spec/integration/basic_subscriber_spec.rb
@@ -25,11 +25,11 @@ describe "A Basic Subscriber", :integration => true do
       exchange = channel.topic("events")
       exchange.publish("Ohai Booked", :routing_key => "greg.basic_push.booked")
       exchange.publish("Ohai Cancelled", :routing_key => "basic.cancelled")
-      sleep 0.1
 
-      ::ActionSubscriber.auto_pop!
-
-      expect($messages).to eq(Set.new(["Ohai Booked", "Ohai Cancelled"]))
+      verify_expectation_within(2.0) do
+        ::ActionSubscriber.auto_pop!
+        expect($messages).to eq(Set.new(["Ohai Booked", "Ohai Cancelled"]))
+      end
     end
   end
 
@@ -40,9 +40,10 @@ describe "A Basic Subscriber", :integration => true do
       exchange = channel.topic("events")
       exchange.publish("Ohai Booked", :routing_key => "greg.basic_push.booked")
       exchange.publish("Ohai Cancelled", :routing_key => "basic.cancelled")
-      sleep 0.1
 
-      expect($messages).to eq(Set.new(["Ohai Booked", "Ohai Cancelled"]))
+      verify_expectation_within(2.0) do
+        expect($messages).to eq(Set.new(["Ohai Booked", "Ohai Cancelled"]))
+      end
     end
   end
 end

--- a/spec/integration/decoding_payloads_spec.rb
+++ b/spec/integration/decoding_payloads_spec.rb
@@ -18,12 +18,13 @@ describe "Payload Decoding", :integration => true do
     channel = connection.create_channel
     exchange = channel.topic("events")
     exchange.publish(json_string, :routing_key => "twitter.tweet", :content_type => "application/json")
-    sleep 0.1
 
-    expect($messages).to eq Set.new([{
-      :decoded => JSON.parse(json_string),
-      :raw => json_string,
-    }])
+    verify_expectation_within(2.0) do
+      expect($messages).to eq Set.new([{
+        :decoded => JSON.parse(json_string),
+        :raw => json_string,
+      }])
+    end
   end
 
   context "Custom Decoder" do
@@ -37,12 +38,13 @@ describe "Payload Decoding", :integration => true do
       channel = connection.create_channel
       exchange = channel.topic("events")
       exchange.publish(json_string, :routing_key => "twitter.tweet", :content_type => content_type)
-      sleep 0.1
 
-      expect($messages).to eq Set.new([{
-        :decoded => :foo,
-        :raw => json_string,
-      }])
+      verify_expectation_within(2.0) do
+        expect($messages).to eq Set.new([{
+          :decoded => :foo,
+          :raw => json_string,
+        }])
+      end
     end
   end
 end

--- a/spec/integration/manual_acknowledgement_spec.rb
+++ b/spec/integration/manual_acknowledgement_spec.rb
@@ -20,8 +20,9 @@ describe "Manual Message Acknowledgment", :integration => true do
     channel = connection.create_channel
     exchange = channel.topic("events")
     exchange.publish("BACON!", :routing_key => "bacon.served")
-    sleep 0.1
 
-    expect($messages).to eq(Set.new(["BACON!::0", "BACON!::1", "BACON!::2"]))
+    verify_expectation_within(2.0) do
+      expect($messages).to eq(Set.new(["BACON!::0", "BACON!::1", "BACON!::2"]))
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,3 +30,17 @@ RSpec.configure do |config|
     end
   end
 end
+
+def verify_expectation_within(number_of_seconds, check_every = 0.02)
+  waiting_since = ::Time.now
+  begin
+    sleep check_every
+    yield
+  rescue RSpec::Expectations::ExpectationNotMetError => e
+    if ::Time.now - waiting_since > number_of_seconds
+      raise e
+    else
+      retry
+    end
+  end
+end


### PR DESCRIPTION
This little branch is just about making the Travis builds and local test runs a lot more stable.
I added the `verify_expectation_within` helper method so we can let Travis run slowly and give it time for the rabbitmq messages to go back and forth, but it still runs very fast locally for me.